### PR TITLE
Fix a bug in the OfficeFactory

### DIFF
--- a/src/Pronamic/Twinfield/Office/OfficeFactory.php
+++ b/src/Pronamic/Twinfield/Office/OfficeFactory.php
@@ -35,7 +35,7 @@ class OfficeFactory extends FinderFactory
     {
         $response = $this->searchFinder(self::TYPE_OFFICES, $pattern, $field, $firstRow, $maxRows, $options);
         $result = $response->data->Items->ArrayOfString;
-        if(count($result) == 1) {
+        if(count((array)$result) == 1) {
             $result = [$result];
         }
 


### PR DESCRIPTION
This PR fixes a bug in the office factory where a `count` was used on an instance of `stdObject`. This is not supported, but casting it to an `array` should do the job.